### PR TITLE
Bootloaders: pass "netinstall" as argument for netinstall images

### DIFF
--- a/scripts/create-install-iso.sh
+++ b/scripts/create-install-iso.sh
@@ -215,7 +215,10 @@ else
     # FIXME: should be generated above instead?
     rm ${VERBOSE} "$ISODIR/.treeinfo"
 
-    # FIXME: trigger netinstall mode?
+    # trigger netinstall mode
+    sed -i -e "s@/vmlinuz@/vmlinuz netinstall@" \
+        "$ISODIR"/*/*/grub*.cfg \
+        "$ISODIR"/boot/isolinux/isolinux.cfg
 fi
 
 


### PR DESCRIPTION
8.3 may end up not needing it, but it's unlikely we backport this to 8.2.