### PR TITLE
create-iso: neutralize junk added by faketime in last FAT sector

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ They require to install some additional packages first:
 
 ```
 sudo yum install -y genisoimage syslinux grub-tools createrepo_c ltfp
-sudo yum install -y --enablerepo=epel gnupg1
+sudo yum install -y --enablerepo=epel gnupg1 libfaketime
 ```
 
 

--- a/scripts/create-install-iso.sh
+++ b/scripts/create-install-iso.sh
@@ -330,6 +330,10 @@ else
     esac
 
     "${FAKETIME[@]}" mformat -i "$ISODIR/boot/efiboot.img" -N 0 -C -f 2880 -L 16 ::.
+    # Under faketime on CentOS 7 the last sector gets "random" contents instead of zero.
+    # We're not sure why (FIXME?) but make sure that data does not leak or polute.
+    dd if=/dev/zero of="$ISODIR/boot/efiboot.img" bs=512 count=1 seek=$((2880*2 - 1))
+
     "${FAKETIME[@]}" mmd     -i "$ISODIR/boot/efiboot.img" ::/EFI ::/EFI/BOOT
     "${FAKETIME[@]}" mcopy   -i "$ISODIR/boot/efiboot.img" "$BOOTX64" ::/EFI/BOOT/BOOTX64.EFI
 


### PR DESCRIPTION
For some reason still to be determined, mformat run under faketime writes into the last sector some non-zero data including the libfaketime path.

Until that problem (which does not appear e.g. on Debian 11) gets fixed, this makes sure we do not leak any arbitrary data, and makes the build reproducible.