### PR TITLE
installimg: include gpg key to check netinstall repos on 8.2

### DIFF
--- a/templates/installimg/8.2/opt/xensource/installer/RPM-GPG-KEY-xcpng
+++ b/templates/installimg/8.2/opt/xensource/installer/RPM-GPG-KEY-xcpng
@@ -1,0 +1,1 @@
+../../../etc/pki/rpm-gpg/RPM-GPG-KEY-xcpng


### PR DESCRIPTION
The 8.2 support implemented in XCP-ng 8.2 requires the key to be in the installer directory, use a symlink for this.