### PR TITLE
create-img: force selection of libverto-tevent

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,8 +16,3 @@
   * still some packages to be cleaned up
     - [ ] limit firwmare to that useable by provided drivers
     - [ ] /var/cache
-* [ ] Packages/ for 8.2.0 contains libverto-libevent instead of
-      libverto-tevent (both fulfill the same Provides). Could it have
-      adverse effects? Does this problem affect 8.3 ISOs? Create a yum
-      conf, used when Packages/ is generated, where in case of doubt
-      libverto-tevent be prefered?

--- a/configs/8.2/packages.lst
+++ b/configs/8.2/packages.lst
@@ -69,7 +69,6 @@ gmp
 gnupg2
 gpgme
 grep
-gssproxy
 gzip
 hardlink
 host-installer-startup
@@ -149,8 +148,7 @@ libtirpc
 libuser
 libutempter
 libuuid
-libverto
-libverto-libevent
+libverto-tevent  # pin libverto-module-base to libverto default
 libxml2
 linux-firmware
 lldpad

--- a/configs/8.3/packages.lst
+++ b/configs/8.3/packages.lst
@@ -74,6 +74,7 @@ kernel-alt
 keyutils
 kmod
 kpartx
+libverto-tevent  # pin libverto-module-base to libverto default
 linux-firmware
 lldpad
 logrotate

--- a/scripts/create-installimg.sh
+++ b/scripts/create-installimg.sh
@@ -124,8 +124,8 @@ YUMFLAGS=(
 yum ${YUMFLAGS[@]} repolist all
 
 PACKAGES_LST=$(find_config packages.lst)
-xargs < "$PACKAGES_LST" \
-    yum ${YUMFLAGS[@]} install \
+sed "s/#.*//" < "$PACKAGES_LST" |
+    xargs yum ${YUMFLAGS[@]} install \
         --assumeyes \
         --noplugins
 


### PR DESCRIPTION
8.2: include libverto-tevent instead of libverto-libevent, and avoid specifying explicitly packages that get pulled as dependencies

8.3: explicitly specify libverto-tevent to be sure

The only known libverto user in XCP-ng dom0 is gssproxy, whose code does not care about which libverto backend will be used, so the choice of which one to use is delegated at runtime to libverto.

libverto has a "default backend" configured, which will be used it available, and this is libverto-tevent in this version.  Having this package installed is the only way to ensure the same lib will be used by gssproxy (and any other similar software, if any), regardless of whether libverto-libevent is also installed.

This is still not perfect, as having libverto-glib installed apparently causes libverto-tevent (for some reason) to also load libglib.so.