### PR TITLE
create-img: nuke xen-installer-files

### DIFF
--- a/configs/8.3/packages.lst
+++ b/configs/8.3/packages.lst
@@ -146,7 +146,6 @@ vendor-drivers
 vim-minimal
 wget
 xen-dom0-tools
-xen-installer-files
 xen-tools
 xcp-ng-release
 xcp-ng-release-presets


### PR DESCRIPTION
Latest xen packaging in 8.3 drops this obsolete package.