### PR TITLE
[8.3] Fix failed journal services on installer boot (#186)

### DIFF
--- a/templates/installimg/8.3/etc/systemd/system/systemd-journal-catalog-update.service
+++ b/templates/installimg/8.3/etc/systemd/system/systemd-journal-catalog-update.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/templates/installimg/8.3/etc/systemd/system/systemd-journal-flush.service
+++ b/templates/installimg/8.3/etc/systemd/system/systemd-journal-flush.service
@@ -1,0 +1,1 @@
+/dev/null


### PR DESCRIPTION
Goal is to fix services failing at boot time in the installer, journald is started without persistent storage and these services are not starting properly because of it.

- `systemd-journal-catalog-update`: only in XCP-ng
    - Link service unit in `etc/systemd/system/` to `/dev/null`
- `systemd-journal-flush`: only in XCP-ng
    - Link service unit in `etc/systemd/system/` to `/dev/null`
