### PR TITLE
Update TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,14 +2,13 @@
 
 * [ ] multipath support ?
     - [ ] /etc/udev/rules.d/40-multipath.rules
-* [ ] extract `.treeinfo` data from branding
-* [ ] let `--define-repo` also take a gpg-key
 * [ ] disable more services
     - [ ] ldconfig.service xenstored.service etc. links to /dev/null (those two at least seem
           unneeded)
     - [ ] /etc/udev/rules.d/: 11-dm-mpath.rules 62-multipath.rules 69-dm-lvm-metad.rules links to /dev/null
 * [ ] improved key handling
-  * allow using a separately-generated-and-signed repository
+  * let `--define-repo` also take a gpg-key or ...
+  * ... allow using a separately-generated-and-signed repository
   * missing in installed system
     - [ ] Citrix rpm keys (driver disks? sup packs?)
 * possible additional cleanups


### PR DESCRIPTION
- forgotten to remove ".treeinfo from branding" when this was implemented
- regroup hypothetical extra gpg work under existing "improved key handling"