### PR TITLE
[8.2] Fix failed journal services on installer boot (#186)

### DIFF
--- a/templates/installimg/8.2/etc/systemd/system/systemd-journal-catalog-update.service
+++ b/templates/installimg/8.2/etc/systemd/system/systemd-journal-catalog-update.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/templates/installimg/8.2/etc/systemd/system/systemd-journal-flush.service
+++ b/templates/installimg/8.2/etc/systemd/system/systemd-journal-flush.service
@@ -1,0 +1,1 @@
+/dev/null


### PR DESCRIPTION
Same as https://github.com/xcp-ng/create-install-image/pull/13, for XCP-ng 8.2.

Taking back previous PR message:

> Goal is to fix services failing at boot time in the installer, journald is started without persistent storage and these services are not starting properly because of it.
>
> - systemd-journal-catalog-update: only in XCP-ng
>   - Link service unit in etc/systemd/system/ to /dev/null
> - systemd-journal-flush: only in XCP-ng
>   - Link service unit in etc/systemd/system/ to /dev/null
