### PR TITLE
Fix `create-installimg --define-repo`

### DIFF
--- a/configs/base/CUSTOMREPO.tmpl
+++ b/configs/base/CUSTOMREPO.tmpl
@@ -2,5 +2,6 @@
 name=xcpng - Custom @@REPOID@@
 baseurl=@@REPOURL@@/@@RPMARCH@@/
 #gpgkey=https://xcp-ng.org/RPM-GPG-KEY-xcpng
+gpgcheck=0
 failovermethod=priority
 skip_if_unavailable=False

--- a/scripts/create-installimg.sh
+++ b/scripts/create-installimg.sh
@@ -102,16 +102,6 @@ cat "$YUMCONF_TMPL" |
     > "$YUMCONF"
 [ -z "$VERBOSE" ] || cat "$YUMCONF"
 
-find_all_configs yum-repos.conf.tmpl | while read YUMREPOSCONF_TMPL; do
-    reponame=$(basename $(dirname "$YUMREPOSCONF_TMPL"))
-    cat "$YUMREPOSCONF_TMPL" |
-        sed \
-            -e "s,@@SRCURL@@,$SRCURL," \
-            -e "s,@@RPMARCH@@,$RPMARCH," \
-            > "$YUMREPOSD/$reponame.repo"
-done
-[ -z "$VERBOSE" ] || ls "$YUMREPOSD"
-
 ROOTFS=$(mktemp -d "$TMPDIR/rootfs-XXXXXX")
 YUMFLAGS=(
     --config="$YUMCONF"
@@ -120,8 +110,7 @@ YUMFLAGS=(
     $([ -n "$VERBOSE" ] || printf -- "-q")
 )
 
-# summary of repos
-yum "${YUMFLAGS[@]}" repolist all
+setup_yum_repos "${YUMFLAGS[@]}"
 
 PACKAGES_LST=$(find_config packages.lst)
 sed "s/#.*//" < "$PACKAGES_LST" |

--- a/scripts/create-installimg.sh
+++ b/scripts/create-installimg.sh
@@ -121,11 +121,11 @@ YUMFLAGS=(
 )
 
 # summary of repos
-yum ${YUMFLAGS[@]} repolist all
+yum "${YUMFLAGS[@]}" repolist all
 
 PACKAGES_LST=$(find_config packages.lst)
 sed "s/#.*//" < "$PACKAGES_LST" |
-    xargs yum ${YUMFLAGS[@]} install \
+    xargs yum "${YUMFLAGS[@]}" install \
         --assumeyes \
         --noplugins
 

--- a/scripts/lib/misc.sh
+++ b/scripts/lib/misc.sh
@@ -169,7 +169,7 @@ setup_yum_download() {
     local YUM=$(command -v yum || command -v dnf) || die "no yum or dnf found"
     # summary of repos
     test ! -r /var/cache/yum/xcpng-base || die "yum system cache should not be there to start with"
-    "$YUM" ${YUMDLFLAGS[@]} repolist all
+    "$YUM" "${YUMDLFLAGS[@]}" repolist all
     # double-check we don't let yum reintroduce that cache by mistake
     test ! -r /var/cache/yum/xcpng-base || die "yum system cache should not have been created"
 }

--- a/scripts/lib/misc.sh
+++ b/scripts/lib/misc.sh
@@ -144,6 +144,11 @@ setup_yum_download() {
         --releasever="$DIST"
     )
 
+    setup_yum_repos "${YUMDLFLAGS[@]}"
+}
+
+setup_yum_repos() {
+    # repos declated in yum-repos.conf.tmpl
     find_all_configs yum-repos.conf.tmpl | while read YUMREPOSCONF_TMPL; do
         reponame=$(basename $(dirname "$YUMREPOSCONF_TMPL"))
         cat "$YUMREPOSCONF_TMPL" |
@@ -153,7 +158,7 @@ setup_yum_download() {
                 > "$YUMREPOSD/$reponame.repo"
     done
 
-    # custom repos
+    # custom repos from cmdline
     CUSTOMREPO_TEMPLATE=$(find_config CUSTOMREPO.tmpl)
     for repoid in "${!CUSTOM_REPOS[@]}"; do
         repourl="${CUSTOM_REPOS[$repoid]}"
@@ -169,7 +174,8 @@ setup_yum_download() {
     local YUM=$(command -v yum || command -v dnf) || die "no yum or dnf found"
     # summary of repos
     test ! -r /var/cache/yum/xcpng-base || die "yum system cache should not be there to start with"
-    "$YUM" "${YUMDLFLAGS[@]}" repolist all
+    [ -z "$VERBOSE" ] || ls "$YUMREPOSD"
+    "$YUM" "$@" repolist all
     # double-check we don't let yum reintroduce that cache by mistake
     test ! -r /var/cache/yum/xcpng-base || die "yum system cache should not have been created"
 }

--- a/scripts/lib/misc.sh
+++ b/scripts/lib/misc.sh
@@ -163,7 +163,6 @@ setup_yum_download() {
                 -e "s,@@REPOURL@@,$repourl," \
                 -e "s,@@RPMARCH@@,$RPMARCH," \
                 > "$YUMREPOSD/$repoid.repo"
-        YUMFLAGS+=("--enablerepo=$repoid")
     done
 
     # availability of yumdownloader does not imply that of yum


### PR DESCRIPTION
While for  `create-install-iso` the `--define-repo` option has been working as expected, it had been broken for `create-installimg` during development of the original PR.