### PR TITLE
Fix alternate upgrade method of XCP-ng

### DIFF
--- a/templates/iso/8.3/.treeinfo
+++ b/templates/iso/8.3/.treeinfo
@@ -1,3 +1,11 @@
+[platform]
+name = @@PLATFORM_NAME@@
+version = @@PLATFORM_VERSION@@
+
+[branding]
+name = @@PRODUCT_BRAND@@
+version = @@PRODUCT_VERSION@@
+
 [system-v1]
 platform_name = @@PLATFORM_NAME@@
 platform_version = @@PLATFORM_VERSION@@


### PR DESCRIPTION
The plugin `prepare_host_upgrade.py` looks for the added entries in the `.treeinfo` in order to do the upgrade.