### PR TITLE
configs/8.3/packages.lst: remove newt-python, already pulled

### DIFF
--- a/configs/8.3/packages.lst
+++ b/configs/8.3/packages.lst
@@ -84,7 +84,6 @@ mdadm
 microsemi-smartpqi
 ncurses
 newt
-newt-python
 nfs-utils
 nspr
 nss


### PR DESCRIPTION
The actual package name is python2-newt, and newt-python is an old package name which was turned into a provides for compatibility.


Updated after review comments:

First, the actual package name is python2-newt, and newt-python is an old
package name which was turned into a provides for compatibility.

Second, it is already explicitly pulled by system-config-firewall-tui.

Let's remove it from the list.