### PR TITLE
misc.sh: use /tmp as mktemp base instead of $PWD

### DIFF
--- a/scripts/lib/misc.sh
+++ b/scripts/lib/misc.sh
@@ -103,7 +103,13 @@ trap 'exitcleanup' EXIT INT
 # getting reused between runs, and confusing yum about which rpm
 # versions should be available.  Yeah that sucks hard.
 # See https://unix.stackexchange.com/questions/92257/
-export TMPDIR=$(mktemp -d "$PWD/tmpdir-XXXXXX")
+# Use realpath -m to canonicalize $PWD before passing it to mktemp:
+# avoids broken file:// URIs when the container working directory is /
+# (Docker's default without WORKDIR), which caused mktemp to produce
+# //tmpdir-XXXXXX and yum to build a file:////tmpdir-... URI that
+# Python 2's urllib cannot open.
+# See: https://xcp-ng.org/forum/topic/12078
+export TMPDIR=$(mktemp -d "$(realpath -m "$PWD")/xcpng-build-XXXXXX")
 CLEANUP_DIRS+=("$TMPDIR")
 
 


### PR DESCRIPTION
The `mktemp -d "$PWD/tmpdir-XXXXXX"` call produces `//tmpdir-XXXXXX` when `PWD` is `/`, which is Docker's default when no WORKDIR is set. Linux normalises the double slash fine, but yum converts the config path to a `file://` URI, giving `file:////tmpdir-...` — which Python 2's urllib cannot open. The error message gives no hint that the working directory is the problem.

Using `mktemp -d -t` keeps the original intent (a unique directory outside `/var/tmp`, so yum cannot reuse cached data between runs) without coupling TMPDIR to the working directory.

Reported via forum: https://xcp-ng.org/forum/topic/12078/build-xcp-ng-iso-issue-at-create-installimg