### PR TITLE
boot: clearly identify XCP-ng 8.3 in GRUB

### DIFF
--- a/templates/iso/8.3/EFI/xenserver/grub.cfg
+++ b/templates/iso/8.3/EFI/xenserver/grub.cfg
@@ -16,42 +16,42 @@ insmod ext2
 
 set timeout=5
 
-menuentry "install" {
+menuentry "Install XCP-ng 8.3"
     multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
     module2 /boot/vmlinuz console=hvc0 console=tty0
     module2 /install.img
 }
 
-menuentry "no-serial" {
+menuentry "Install (no-serial)" {
     multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M console=vga
     module2 /boot/vmlinuz console=tty0
     module2 /install.img
 }
 
-menuentry "safe" {
+menuentry "Install (safe)" {
     multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M nosmp noreboot noirqbalance no-mce no-bootscrub no-numa no-hap no-mmcfg max_cstate=0 nmi=ignore allow_unsafe com1=115200,8n1 console=com1,vga vga=keep
     module2 /boot/vmlinuz console=hvc0 console=tty0
     module2 /install.img
 }
 
-menuentry "multipath" {
+menuentry "Install (with device-mapper multipath)" {
     multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
     module2 /boot/vmlinuz console=hvc0 console=tty0 device_mapper_multipath=enabled
     module2 /install.img
 }
 
-menuentry "install with alternate/debug kernel (kernel-alt)" {
+menuentry "Install with alternate/debug kernel (kernel-alt)" {
     multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
     module2 /boot/alt/vmlinuz console=hvc0 console=tty0 kernel-alt
     module2 /install.img
 }
 
-menuentry "shell" {
+menuentry "Shell" {
     multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
     module2 /boot/vmlinuz console=hvc0 console=tty0 bash-shell
     module2 /install.img
 }
 
-menuentry "memtest" {
+menuentry "Memtest" {
     chainloader /boot/memtest.efi
 }


### PR DESCRIPTION
On UEFI machines, there was no clear way to tell what you're about to install. However, now the GRUB menu is no longer generic.