### PR TITLE
Fix (again) instructions for linstor ISO with 8.2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ sudo ./scripts/create-installimg.sh \
     --srcurl file://$HOME/mirrors/xcpng/8.3 \
     --srcurl:linstor file://$HOME/mirrors/xcpng-rvt/8.3 \
     --output xcp-ng-8.3.linstor.iso \
-    --extra-packages "xcp-ng-release-linstor xcp-ng-linstor linstor-satellite-$LINSTOR82 linstor-controller-$LINSTOR82" \
+    --extra-packages "xcp-ng-release-linstor xcp-ng-linstor linstor-satellite-$LINSTOR82 linstor-controller-$LINSTOR82 linstor-common-$LINSTOR82" \
     -V "XCP-NG_830_TEST" \
     8.3:updates:linstor install-8.3.img
 ```


### PR DESCRIPTION
Fix in 1ecbb35ac2e7ea5e3c7b18579ceafab691ea6447 (Fix instructions for linstor ISO with 8.2 compatibility) missed the linstor-common package.